### PR TITLE
Add censys, onyphe checks and select checks by tag or  config file

### DIFF
--- a/check/censys.go
+++ b/check/censys.go
@@ -1,0 +1,128 @@
+package check
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/jreisinger/checkip"
+)
+
+type censys struct {
+	Result result `json:"result"`
+}
+
+type result struct {
+	Data censysData      `json:"services"`
+	OS   operatingSystem `json:"operating_system"`
+}
+
+type operatingSystem struct {
+	Product                   string `json:"product"`
+	Vendor                    string `json:"vendor"`
+	Version                   string `json:"version"`
+	Edition                   string `json:"edition"`
+}
+
+type censysData []struct {
+	Port                int    `json:"port"`
+	Transport           string `json:"transport_protocol"` // tcp, udp
+	ServiceName         string `json:"service_name"`
+	ExtendedServiceName string `json:"extended_service_name"`
+}
+
+var censysUrl = "https://search.censys.io/api/v2"
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+// Censys gets generic information from search.censys.io.
+func Censys(ipaddr net.IP) (checkip.Result, error) {
+	result := checkip.Result{
+		Name: "censys.io",
+		Type: checkip.TypeInfoSec,
+	}
+
+	apiKey, err := getConfigValue("CENSYS_KEY")
+	if err != nil {
+		return result, newCheckError(err)
+	}
+	if apiKey == "" {
+		return result, nil
+	}
+
+	apiSec, err := getConfigValue("CENSYS_SEC")
+	if err != nil {
+		return result, newCheckError(err)
+	}
+	if apiSec == "" {
+		return result, nil
+	}
+
+	headers := map[string]string{
+		"Authorization": "Basic " + basicAuth(apiKey, apiSec),
+		"Accept":        "application/json",
+		"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
+	}
+
+	var censys censys
+	apiURL := fmt.Sprintf("%s/hosts/%s", censysUrl, ipaddr)
+	if err := defaultHttpClient.GetJson(apiURL, headers, map[string]string{}, &censys); err != nil {
+		return result, newCheckError(err)
+	}
+	result.Info = censys
+
+	for _, d := range censys.Result.Data {
+		port := d.Port
+		if port != 80 && port != 443 && port != 53 { // undecidable ports
+			result.Malicious = true
+		}
+	}
+
+	return result, nil
+}
+
+type byPortC censysData
+
+func (x byPortC) Len() int           { return len(x) }
+func (x byPortC) Less(i, j int) bool { return x[i].Port < x[j].Port }
+func (x byPortC) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+
+// Info returns interesting information from the check.
+func (c censys) Summary() string {
+	var portInfo []string
+	var os string
+	if c.Result.OS.Product != "" {
+		os = c.Result.OS.Product
+	}
+	var osvendor string
+	if c.Result.OS.Vendor != "" {
+		osvendor = c.Result.OS.Vendor
+	}
+
+	service := make(map[string]int)
+	sort.Sort(byPortC(c.Result.Data))
+	for _, d := range c.Result.Data {
+		port := d.Port
+
+		sport := fmt.Sprintf("%s/%d", strings.ToLower(d.Transport), port)
+		service[sport]++
+
+		if service[sport] > 1 {
+			continue
+		}
+
+		portInfo = append(portInfo, fmt.Sprintf("%s (%s)", sport, strings.ToLower(d.ServiceName)))
+	}
+
+	return fmt.Sprintf("OS: %s, open: %s", strings.Join(nonEmpty(os, osvendor), ", "), strings.Join(portInfo, ", "))
+}
+
+func (c censys) Json() ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/check/censys_test.go
+++ b/check/censys_test.go
@@ -1,0 +1,63 @@
+package check
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/jreisinger/checkip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCensys(t *testing.T) {
+
+	apiKey, err := getConfigValue("CENSYS_KEY")
+	if err != nil || apiKey == "" {
+		return
+	}
+	apiSec, err := getConfigValue("CENSYS_SEC")
+	if err != nil || apiSec == "" {
+		return
+	}
+
+	t.Run("given valid response then result and no error is returned", func(t *testing.T) {
+		handlerFn := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write(loadResponse(t, "censys_response.json"))
+		})
+
+		testUrl := setMockHttpClient(t, handlerFn)
+		setCensysUrl(t, testUrl)
+
+		result, err := Censys(net.ParseIP("118.25.6.39"))
+		require.NoError(t, err)
+		assert.Equal(t, "censys.io", result.Name)
+		assert.Equal(t, checkip.TypeInfoSec, result.Type)
+		assert.Equal(t, true, result.Malicious)
+		assert.Equal(t, "OS: RB760iGS, MikroTik, open: udp/161 (snmp), tcp/2000 (mikrotik_bw), tcp/51922 (ssh)", result.Info.Summary())
+	})
+
+
+	t.Run("given non 2xx response then error is returned", func(t *testing.T) {
+		handlerFn := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		})
+
+		testUrl := setMockHttpClient(t, handlerFn)
+		setCensysUrl(t, testUrl)
+
+		_, err := Censys(net.ParseIP("118.25.6.39"))
+		require.Error(t, err)
+	})
+}
+
+// --- test helpers ---
+
+func setCensysUrl(t *testing.T, testUrl string) {
+	url := censysUrl
+	censysUrl = testUrl
+	t.Cleanup(func() {
+		censysUrl = url
+	})
+}

--- a/check/check.go
+++ b/check/check.go
@@ -7,11 +7,20 @@ import (
 	"github.com/jreisinger/checkip"
 )
 
+// Use : function list to be used in checks
+var Use = []checkip.Check{}
+
+// AddUse : methode to add function in checks
+func AddUse(s interface{}) {
+	Use = append(Use,s.(checkip.Check))
+}
+
 // All contains all available checks.
 var All = []checkip.Check{
 	AbuseIPDB,
 	BlockList,
 	CinsScore,
+	Censys,
 	DBip,
 	DnsMX,
 	DnsName,
@@ -21,6 +30,7 @@ var All = []checkip.Check{
 	IsOnAWS,
 	MaxMind,
 	OTX,
+	Onyphe,
 	PhishStats,
 	Ping,
 	SansISC,

--- a/check/config.go
+++ b/check/config.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// GetConfigValue export getConfigValue function for main
+func GetConfigValue(key string) (string, error) {
+	return getConfigValue(key)
+}
+
 // getConfigValue tries to get value for key first from an environment variable
 // then from a configuration file at $HOME/.checkip.yaml. If value is not found
 // an empty string and nil is returned (i.e. it's not considered an error).

--- a/check/onyphe.go
+++ b/check/onyphe.go
@@ -1,0 +1,148 @@
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"strconv"
+
+	"github.com/jreisinger/checkip"
+)
+
+type onyphe struct {
+	Text    string     `json:"text"`
+	Vulns   []string   `json:"vulns"`
+	Results onypheData `json:"results"`
+}
+
+type onypheData []struct {
+	OS       string `json:"os"`
+	OsVendor string `json:"osvendor"`
+	//Version   string `json:"version"`
+	Port      interface{} `json:"port"`
+	Protocol  string      `json:"protocol"`
+	Product   string      `json:"product"`
+	Transport string      `json:"transport"` // tcp, udp
+}
+
+var onypheUrl = "https://www.onyphe.io/api/v2"
+
+// Onyphe gets generic information from api.onyphe.io.
+func Onyphe(ipaddr net.IP) (checkip.Result, error) {
+	result := checkip.Result{
+		Name: "onyphe.io",
+		Type: checkip.TypeInfoSec,
+	}
+
+	apiKey, err := getConfigValue("ONYPHE_API_KEY")
+	if err != nil {
+		return result, newCheckError(err)
+	}
+	if apiKey == "" {
+		return result, nil
+	}
+
+	headers := map[string]string{
+		"Authorization": "bearer " + apiKey,
+		"Accept":        "application/json",
+		//"Content-Type": "application/x-www-form-urlencoded",
+	}
+	var onyphe onyphe
+	apiURL := fmt.Sprintf("%s/simple/datascan/%s", onypheUrl, ipaddr)
+	if err := defaultHttpClient.GetJson(apiURL, headers, map[string]string{}, &onyphe); err != nil {
+		return result, newCheckError(err)
+	}
+
+	for _, d := range onyphe.Results {
+		var port string
+		switch v := d.Port.(type) {
+		case float64:
+			port = fmt.Sprintf("%d", int(v))
+		case string:
+			port = v
+		}
+		if port != "80" && port != "443" && port != "53" { // undecidable ports
+			result.Malicious = true
+		}
+	}
+
+	result.Info = onyphe
+
+	return result, nil
+}
+
+type byPortO onypheData
+
+func (x byPortO) Len() int { return len(x) }
+func (x byPortO) Less(i, j int) bool {
+	var portI float64
+	var portJ float64
+	switch v := x[i].Port.(type) {
+	case float64:
+		portI = v
+	case string:
+		portI, _ = strconv.ParseFloat(v, 64)
+	}
+	switch v := x[j].Port.(type) {
+	case float64:
+		portJ = v
+	case string:
+		portJ, _ = strconv.ParseFloat(v, 64)
+	}
+	return portI < portJ
+}
+
+func (x byPortO) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+// Info returns interesting information from the check.
+func (o onyphe) Summary() string {
+	var portInfo []string
+	service := make(map[string]int)
+	sort.Sort(byPortO(o.Results))
+	for _, d := range o.Results {
+		var os string
+		if d.OS != "" {
+			os = d.OS
+		}
+
+		var osvendor string
+		if d.OsVendor != "" {
+			osvendor = d.OsVendor
+		}
+
+		var product string
+		if d.Product != "" {
+			product = d.Product + " "
+		}
+
+		var port string
+		switch v := d.Port.(type) {
+		case float64:
+			port = fmt.Sprintf("%d", int(v))
+		case string:
+			port = v
+		}
+
+		sport := fmt.Sprintf("%s/%s", d.Transport, port)
+		service[sport]++
+
+		if service[sport] > 1 {
+			continue
+		}
+
+		if os == "" && osvendor == "" {
+			portInfo = append(portInfo, fmt.Sprintf("%s %s/%s", d.Protocol, d.Transport, port))
+		} else {
+			ss := nonEmpty(os, osvendor)
+			portInfo = append(portInfo, fmt.Sprintf("%s %s/%s %s(%s)", d.Protocol, d.Transport, port, product, strings.Join(ss, ", ")))
+		}
+	}
+
+	return fmt.Sprintf("Open: %s", strings.Join(portInfo, ", "))
+}
+
+func (o onyphe) Json() ([]byte, error) {
+	return json.Marshal(o)
+}

--- a/check/onyphe.go
+++ b/check/onyphe.go
@@ -58,10 +58,10 @@ func Onyphe(ipaddr net.IP) (checkip.Result, error) {
 	for _, d := range onyphe.Results {
 		var port string
 		switch v := d.Port.(type) {
-		case float64:
-			port = fmt.Sprintf("%d", int(v))
 		case string:
 			port = v
+		default:
+			port = fmt.Sprintf("%d", v)
 		}
 		if port != "80" && port != "443" && port != "53" { // undecidable ports
 			result.Malicious = true
@@ -77,21 +77,17 @@ type byPortO onypheData
 
 func (x byPortO) Len() int { return len(x) }
 func (x byPortO) Less(i, j int) bool {
-	var portI float64
-	var portJ float64
+	var portI int
+	var portJ int
 	switch v := x[i].Port.(type) {
-	case float64:
-		portI = v
 	case string:
-		portI, _ = strconv.ParseFloat(v, 64)
+		portI, _ = strconv.Atoi(v)
+    case float64:
+	    portI = int(v)
+    case int:
+	    portI = v
 	}
-	switch v := x[j].Port.(type) {
-	case float64:
-		portJ = v
-	case string:
-		portJ, _ = strconv.ParseFloat(v, 64)
-	}
-	return portI < portJ
+	return portI > portJ
 }
 
 func (x byPortO) Swap(i, j int) { x[i], x[j] = x[j], x[i] }

--- a/check/onyphe_test.go
+++ b/check/onyphe_test.go
@@ -12,12 +12,8 @@ import (
 
 func TestOnyphe(t *testing.T) {
 
-	apiKey, err := getConfigValue("CENSYS_KEY")
+	apiKey, err := getConfigValue("ONYPHE_API_KEY")
 	if err != nil || apiKey == "" {
-		return
-	}
-	apiSec, err := getConfigValue("CENSYS_SEC")
-	if err != nil || apiSec == "" {
 		return
 	}
 

--- a/check/onyphe_test.go
+++ b/check/onyphe_test.go
@@ -1,0 +1,63 @@
+package check
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/jreisinger/checkip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnyphe(t *testing.T) {
+
+	apiKey, err := getConfigValue("CENSYS_KEY")
+	if err != nil || apiKey == "" {
+		return
+	}
+	apiSec, err := getConfigValue("CENSYS_SEC")
+	if err != nil || apiSec == "" {
+		return
+	}
+
+	t.Run("given valid response then result and no error is returned", func(t *testing.T) {
+		handlerFn := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write(loadResponse(t, "onyphe_response.json"))
+		})
+
+		testUrl := setMockHttpClient(t, handlerFn)
+		setOnypheUrl(t, testUrl)
+
+		result, err := Onyphe(net.ParseIP("118.25.6.39"))
+		require.NoError(t, err)
+		assert.Equal(t, "onyphe.io", result.Name)
+		assert.Equal(t, checkip.TypeInfoSec, result.Type)
+		assert.Equal(t, true, result.Malicious)
+		assert.Equal(t, "Open: snmp udp/161 (RouterOS, Mikrotik), winbox tcp/8291 (Linux Kernel, Linux)", result.Info.Summary())
+	})
+
+
+	t.Run("given non 2xx response then error is returned", func(t *testing.T) {
+		handlerFn := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		})
+
+		testUrl := setMockHttpClient(t, handlerFn)
+		setOnypheUrl(t, testUrl)
+
+		_, err := Onyphe(net.ParseIP("118.25.6.39"))
+		require.Error(t, err)
+	})
+}
+
+// --- test helpers ---
+
+func setOnypheUrl(t *testing.T, testUrl string) {
+	url := onypheUrl
+	onypheUrl = testUrl
+	t.Cleanup(func() {
+		onypheUrl = url
+	})
+}

--- a/check/testdata/censys_response.json
+++ b/check/testdata/censys_response.json
@@ -1,0 +1,168 @@
+{
+    "code": 200,
+    "result": {
+        "autonomous_system": {
+            "asn": 0,
+            "bgp_prefix": "10.20.80.0/21",
+            "country_code": "BR",
+            "description": "SERVICOS DE TELECOM",
+            "name": "SERVICOS DE TELECOM"
+        },
+        "autonomous_system_updated_at": "2024-04-19T11:18:35.426760638Z",
+        "dns": {
+            "reverse_dns": {
+                "names": [
+                    "exemple.org"
+                ],
+                "resolved_at": "2024-05-21T08:16:15.901097328Z"
+            }
+        },
+        "ip": "10.20.84.2",
+        "labels": [
+            "network-administration",
+            "network.device",
+            "remote-access"
+        ],
+        "last_updated_at": "2024-06-04T04:19:53.614Z",
+        "location": {
+            "city": "Fortaleza",
+            "continent": "South America",
+            "coordinates": {
+                "latitude": -3.70000,
+                "longitude": -38.00000
+            },
+            "country": "Brazil",
+            "country_code": "BR",
+            "postal_code": "60000-000",
+            "province": "Ceará",
+            "timezone": "America/Fortaleza"
+        },
+        "location_updated_at": "2024-05-29T11:18:35.426738659Z",
+        "operating_system": {
+            "other": {
+                "device": "Router",
+                "family": "RouterOS"
+            },
+            "part": "o",
+            "product": "RB760iGS",
+            "uniform_resource_identifier": "cpe:2.3:o:mikrotik:rb760igs:*:*:*:*:*:*:*:*",
+            "vendor": "MikroTik"
+        },
+        "services": [
+            {
+                "_decoded": "snmp",
+                "discovery_method": "PREDICTIVE_METHOD_7",
+                "extended_service_name": "SNMP",
+                "labels": [
+                    "network-administration"
+                ],
+                "observed_at": "2024-06-03T21:51:32.698760154Z",
+                "perspective_id": "PERSPECTIVE_HE",
+                "port": 161,
+                "service_name": "SNMP",
+                "snmp": {},
+                "software": [
+                    {
+                        "other": {
+                            "device": "Router",
+                            "family": "RouterOS"
+                        },
+                        "part": "o",
+                        "product": "RB760iGS",
+                        "source": "OSI_APPLICATION_LAYER",
+                        "uniform_resource_identifier": "cpe:2.3:o:mikrotik:rb760igs:*:*:*:*:*:*:*:*",
+                        "vendor": "MikroTik"
+                    }
+                ],
+                "source_ip": "192.168.125.204",
+                "transport_protocol": "UDP",
+                "truncated": false
+            },
+            {
+                "_decoded": "banner_grab",
+                "_encoding": {
+                    "banner": "DISPLAY_UTF8",
+                    "banner_hex": "DISPLAY_HEX"
+                },
+                "banner": "\u0001\u0000\u0000\u0000",
+                "banner_hashes": [
+                    ""
+                ],
+                "banner_hex": "01000000",
+                "discovery_method": "IPV4_WALK_FULL_PRIORITY_1",
+                "extended_service_name": "MIKROTIK_BW",
+                "observed_at": "2024-06-04T03:58:59.168261755Z",
+                "perspective_id": "PERSPECTIVE_TATA",
+                "port": 2000,
+                "service_name": "MIKROTIK_BW",
+                "software": [
+                    {
+                        "part": "o",
+                        "product": "Linux",
+                        "source": "OSI_TRANSPORT_LAYER",
+                        "uniform_resource_identifier": "cpe:2.3:o:*:linux:*:*:*:*:*:*:*:*"
+                    }
+                ],
+                "source_ip": "192.168.138.113",
+                "transport_fingerprint": {
+                    "id": 15,
+                    "os": "device25",
+                    "raw": "14480,64,true,MSTNW,1460,false,false"
+                },
+                "transport_protocol": "TCP",
+                "truncated": false
+            },
+            {
+                "_decoded": "ssh",
+                "_encoding": {
+                    "banner": "DISPLAY_UTF8",
+                    "banner_hex": "DISPLAY_HEX"
+                },
+                "banner": "SSH-2.0-ROSSSH",
+                "banner_hashes": [
+                    ""
+                ],
+                "banner_hex": "",
+                "discovery_method": "PREDICTIVE_METHOD_20",
+                "extended_service_name": "SSH",
+                "labels": [
+                    "remote-access",
+                    "network.device"
+                ],
+                "observed_at": "2024-06-04T04:14:51.357372990Z",
+                "perspective_id": "PERSPECTIVE_TATA",
+                "port": 51922,
+                "service_name": "SSH",
+                "software": [
+                    {
+                        "other": {
+                            "device": "Router",
+                            "family": "RouterOS"
+                        },
+                        "part": "o",
+                        "product": "RouterOS",
+                        "source": "OSI_APPLICATION_LAYER",
+                        "uniform_resource_identifier": "cpe:2.3:o:mikrotik:routeros:*:*:*:*:*:*:*:*",
+                        "vendor": "MikroTik"
+                    }
+                ],
+                "source_ip": "192.168.138.48",
+                "ssh": {},
+                "transport_protocol": "TCP",
+                "truncated": false
+            }
+        ],
+        "whois": {
+            "network": {
+                "cidrs": [
+                    "10.20.64.0/18"
+                ],
+                "created": "2007-06-13T00:00:00Z",
+                "handle": "PASxxx",
+                "name": "SERVICOS DE TELECOM",
+                "updated": "2024-01-20T00:00:00Z"
+            }
+        }
+    },
+    "status": "OK"
+}

--- a/check/testdata/onyphe_response.json
+++ b/check/testdata/onyphe_response.json
@@ -1,0 +1,198 @@
+{
+    "count": 3,
+    "error": 0,
+    "max_page": 1,
+    "myip": "192.168.1.3",
+    "page": 1,
+    "page_size": 3,
+    "results": [
+        {
+            "@category": "datascan",
+            "@timestamp": "2024-06-03T00:09:07.000Z",
+            "app": {
+                "length": 20
+            },
+            "asn": "AS0",
+            "city": "Fortaleza",
+            "country": "BR",
+            "data": "",
+            "datamd5": "",
+            "datammh3": 0,
+            "domain": [
+                "example.org"
+            ],
+            "geolocus": {
+                "asn": "AS0",
+                "continent": "SA",
+                "continentname": "South America",
+                "country": "BR",
+                "countryname": "Brazil",
+                "domain": [
+                    "cert.br",
+                    "example.org"
+                ],
+                "isineu": "false",
+                "latitude": "-14.000000",
+                "location": "-14.000000,-51.00000",
+                "longitude": "-51.00000",
+                "netname": "",
+                "organization": "SERVICOS DE TELECOM",
+                "subnet": "10.20.64.0/18"
+            },
+            "host": [
+                "10.20-84-242"
+            ],
+            "hostname": [
+                "10.20-84-242.example.org"
+            ],
+            "ip": "10.20.84.242",
+            "ipv6": "false",
+            "latitude": "-3.0000",
+            "location": "-3.0000,-38.0000",
+            "longitude": "-38.0000",
+            "node": {
+            },
+            "organization": "SERVICOS DE TELECOM",
+            "os": "Linux Kernel",
+            "osvendor": "Linux",
+            "port": 8291,
+            "protocol": "winbox",
+            "reverse": [
+                "10.20-84-242.example.org"
+            ],
+            "seen_date": "2024-06-03",
+            "source": "datascan",
+            "subnet": "10.20.64.0/18",
+            "tld": [
+                "com.br"
+            ],
+            "tls": "false",
+            "transport": "tcp"
+        },
+        {
+            "@category": "datascan",
+            "@timestamp": "2024-05-08T09:54:12.000Z",
+            "app": {
+                "length": 20
+            },
+            "asn": "AS0",
+            "city": "Fortaleza",
+            "country": "BR",
+            "data": "",
+            "datamd5": "",
+            "datammh3": 0,
+            "domain": [
+                "example.org"
+            ],
+            "geolocus": {
+                "asn": "AS0",
+                "continent": "SA",
+                "continentname": "South America",
+                "country": "BR",
+                "countryname": "Brazil",
+                "domain": [
+                    "cert.br",
+                    "example.org"
+                ],
+                "isineu": "false",
+                "latitude": "-14.000000",
+                "location": "-14.000000,-51.00000",
+                "longitude": "-51.00000",
+                "netname": "",
+                "organization": "SERVICOS DE TELECOM",
+                "subnet": "10.20.64.0/18"
+            },
+            "host": [
+                "10.20-84-242"
+            ],
+            "hostname": [
+                "10.20-84-242.example.org"
+            ],
+            "ip": "10.20.84.242",
+            "ipv6": "false",
+            "latitude": "-3.0000",
+            "location": "-3.0000,-38.0000",
+            "longitude": "-38.0000",
+            "node": {
+            },
+            "organization": "SERVICOS DE TELECOM",
+            "os": "Linux Kernel",
+            "osvendor": "Linux",
+            "port": 8291,
+            "protocol": "winbox",
+            "reverse": [
+                "10.20-84-242.example.org"
+            ],
+            "seen_date": "2024-05-08",
+            "source": "datascan",
+            "subnet": "10.20.64.0/18",
+            "tld": [
+                "com.br"
+            ],
+            "tls": "false",
+            "transport": "tcp"
+        },
+        {
+            "@category": "datascan",
+            "@timestamp": "2024-05-07T12:19:10.000Z",
+            "app": {
+                "length": "60"
+            },
+            "asn": "AS0",
+            "city": "Fortaleza",
+            "country": "BR",
+            "data": "",
+            "datamd5": "",
+            "device": {
+            },
+            "domain": [
+                "example.org"
+            ],
+            "geolocus": {
+                "asn": "AS0",
+                "continent": "SA",
+                "continentname": "South America",
+                "country": "BR",
+                "countryname": "Brazil",
+                "isineu": "false",
+                "latitude": "-14.000000",
+                "location": "-14.000000,-51.00000",
+                "longitude": "-51.00000",
+                "netname": "",
+                "organization": "SERVICOS DE TELECOM",
+                "subnet": "10.20.64.0/18"
+            },
+            "host": [
+                "10.20-84-242"
+            ],
+            "hostname": [
+                "10.20-84-242.example.org"
+            ],
+            "ip": "10.20.84.242",
+            "ipv6": "false",
+            "latitude": "-3.0000",
+            "location": "-3.0000,-38.0000",
+            "longitude": "-38.0000",
+            "organization": "SERVICOS DE TELECOM",
+            "os": "RouterOS",
+            "osvendor": "Mikrotik",
+            "port": "161",
+            "protocol": "snmp",
+            "reverse": [
+                "10.20-84-242.example.org"
+            ],
+            "seen_date": "2024-05-07",
+            "source": "udpscan",
+            "subnet": "10.20.64.0/18",
+            "tld": [
+                "com.br"
+            ],
+            "tls": "false",
+            "transport": "udp"
+        }
+    ],
+    "status": "ok",
+    "text": "Success",
+    "took": 0.119,
+    "total": 3
+}

--- a/cmd/checkip/checkip.go
+++ b/cmd/checkip/checkip.go
@@ -8,6 +8,9 @@ import (
 	"log"
 	"net"
 	"os"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/jreisinger/checkip/check"
@@ -21,6 +24,7 @@ func init() {
 
 var a = flag.Bool("a", false, "run all available checks")
 var j = flag.Bool("j", false, "output all results in JSON")
+var t = flag.String("t", "", "list of checks")
 var c = flag.Int("c", 5, "IP addresses being checked concurrently")
 
 type IpAndResults struct {
@@ -28,10 +32,65 @@ type IpAndResults struct {
 	Results cli.Results
 }
 
+var funcRegistry = make(map[string]interface{})
+var funcDefaultRegistry = make(map[string]int)
+
+func init() {
+	for _, v := range check.All {
+		name := runtime.FuncForPC(reflect.ValueOf(v).Pointer()).Name()
+		funcRegistry[name] = v
+	}
+	for _, v := range check.Default {
+		name := runtime.FuncForPC(reflect.ValueOf(v).Pointer()).Name()
+		funcDefaultRegistry[name] = 1
+	}
+}
+
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s [-flag] IP [IP liste]\n", os.Args[0])
+
+		flag.PrintDefaults()
+
+		fmt.Fprintf(os.Stderr, "  * All checks : ")
+		for v := range funcRegistry {
+			v = strings.Replace(v, "github.com/jreisinger/checkip/check.", "", -1)
+			fmt.Fprintf(os.Stderr, "%s, ", v)
+		}
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintf(os.Stderr, "  * Default checks : ")
+		for v := range funcDefaultRegistry {
+			v = strings.Replace(v, "github.com/jreisinger/checkip/check.", "", -1)
+			fmt.Fprintf(os.Stderr, "%s, ", v)
+		}
+		fmt.Fprintln(os.Stderr, "")
+	}
+
 	flag.Parse()
 
+	tcheck := ""
+	if *t == "" {
+		tcheck, _ = check.GetConfigValue("CHECKS")
+	} else {
+		tcheck = *t
+	}
+	tcheck = strings.Replace(tcheck, " ", "", -1)
+	split := strings.Split(tcheck, ",")
+	for _, s := range split {
+		fname := "github.com/jreisinger/checkip/check." + s
+		if funcRegistry[fname] != nil {
+			check.AddUse(funcRegistry[fname])
+		}
+	}
+
+	use := check.Use
+
 	checks := check.Default
+	if len(use) > 0 {
+		fmt.Println("Checks: " + tcheck)
+		checks = use
+	}
+
 	if *a {
 		checks = check.All
 	}


### PR DESCRIPTION
Thx for your nice tool

here a pull request with censys and onyphe checks

and ability to selects checks by flag or in config file with a CHECKS key
CHECKS: BlockList, CinsScore,

```
Usage of checkip [-flag] IP [IP liste]
  -a	run all available checks
  -c int
    	IP addresses being checked concurrently (default 5)
  -j	output all results in JSON
  -t string
    	list of checks
  * All checks : MaxMind, OTX, PhishStats, Shodan, UrlScan, IPtoASN, Firehol, DnsMX, IsOnAWS, Onyphe, Tls, VirusTotal, CinsScore, BlockList, Censys, DBip, DnsName, IPSum, Ping, SansISC, AbuseIPDB, 
  * Default checks : Ping, Tls, DnsName, Firehol, IPtoASN, IsOnAWS, OTX, BlockList, CinsScore, DBip, IPSum, Shodan
```

```
$ cat ~/.checkip.yaml
CHECKS: Shodan, Onyphe, Tls
```